### PR TITLE
fix: safe json file reading

### DIFF
--- a/src/utils/json-parse-safe.ts
+++ b/src/utils/json-parse-safe.ts
@@ -1,7 +1,0 @@
-export function jsonParseSafe(string: string) {
-	try {
-		return JSON.parse(string);
-	} catch {
-		return null;
-	}
-}

--- a/src/utils/read-json-file.ts
+++ b/src/utils/read-json-file.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+
+export function readJsonFile<JsonType>(filePath: string) {
+	try {
+		const jsonString = fs.readFileSync(filePath, 'utf8');
+		return JSON.parse(jsonString) as JsonType;
+	} catch {}
+}


### PR DESCRIPTION
## Problem

There seems to be cases where the cache file doesn't exist. Perhaps to a race condition. The `fs.readFile()` fails when it can't find the file.

<details>
<summary>Error in logs</summary>

https://github.com/vitejs/vite/runs/6418503465?check_suite_focus=true
```
packages/plugin-vue-jsx build: Error: ENOENT: no such file or directory, open '/tmp/esbuild-kit/16524-00feb6450fc6be613dd946e29c4c113ed0eba8c5'
packages/plugin-vue-jsx build:     at Object.openSync (fs.js:498:3)
packages/plugin-vue-jsx build:     at Object.readFileSync (fs.js:394:35)
packages/plugin-vue-jsx build:     at Map.get (/home/runner/work/vite/vite/node_modules/.pnpm/@esbuild-kit+core-utils@1.0.0/node_modules/@esbuild-kit/core-utils/dist/index.js:3943:48)
packages/plugin-vue-jsx build:     at Object.transformSync (/home/runner/work/vite/vite/node_modules/.pnpm/@esbuild-kit+core-utils@1.0.0/node_modules/@esbuild-kit/core-utils/dist/index.js:4021:26)
packages/plugin-vue-jsx build:     at Object.f (/home/runner/work/vite/vite/node_modules/.pnpm/@esbuild-kit+cjs-loader@1.0.0/node_modules/@esbuild-kit/cjs-loader/dist/index.js:1:423)
packages/plugin-vue-jsx build:     at Module.load (internal/modules/cjs/loader.js:950:32)
packages/plugin-vue-jsx build:     at Function.Module._load (internal/modules/cjs/loader.js:790:12)
packages/plugin-vue-jsx build:     at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
packages/plugin-vue-jsx build:     at ModuleJob.run (internal/modules/esm/module_job.js:1[83](https://github.com/vitejs/vite/runs/6418503465?check_suite_focus=true#step:7:83):25)
packages/plugin-vue-jsx build:     at async Loader.import (internal/modules/esm/loader.js:178:24) {
packages/plugin-vue-jsx build:   errno: -2,
packages/plugin-vue-jsx build:   syscall: 'open',
packages/plugin-vue-jsx build:   code: 'ENOENT',
packages/plugin-vue-jsx build:   path: '/tmp/esbuild-kit/16524-00feb6450fc6be613dd[94](https://github.com/vitejs/vite/runs/6418503465?check_suite_focus=true#step:7:94)6e29c4c113ed0eba8c5'
packages/plugin-vue-jsx build: }
```

https://github.com/vitejs/vite/runs/6419146546?check_suite_focus=true
```
packages/plugin-react build: Error: ENOENT: no such file or directory, open '/tmp/esbuild-kit/16524-735bf333f56916b956f6f051f21b740c0249c247'
packages/plugin-react build:     at Object.openSync (node:fs:590:3)
packages/plugin-react build:     at Object.readFileSync (node:fs:458:35)
packages/plugin-react build:     at FileCache.get (/home/runner/work/vite/vite/node_modules/.pnpm/@esbuild-kit+core-utils@1.0.0/node_modules/@esbuild-kit/core-utils/dist/index.js:3943:48)
packages/plugin-react build:     at Object.transformSync (/home/runner/work/vite/vite/node_modules/.pnpm/@esbuild-kit+core-utils@1.0.0/node_modules/@esbuild-kit/core-utils/dist/index.js:4021:26)
packages/plugin-react build:     at Object.f (/home/runner/work/vite/vite/node_modules/.pnpm/@esbuild-kit+cjs-loader@1.0.0/node_modules/@esbuild-kit/cjs-loader/dist/index.js:1:423)
packages/plugin-react build:     at Module.load (node:internal/modules/cjs/loader:981:32)
packages/plugin-react build:     at Module._load (node:internal/modules/cjs/loader:827:12)
packages/plugin-react build:     at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:170:29)
packages/plugin-react build:     at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
packages/plugin-react build:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
packages/plugin-react build:   errno: -2,
packages/plugin-react build:   syscall: 'open',
packages/plugin-react build:   code: 'ENOENT',
packages/plugin-react build:   path: '/tmp/esbuild-kit/16524-735bf333f56[91](https://github.com/vitejs/vite/runs/6419146546?check_suite_focus=true#step:7:91)6b[95](https://github.com/vitejs/vite/runs/6419146546?check_suite_focus=true#step:7:95)6f6f051f21b740c0249c247'
packages/plugin-react build: }
```

</details>

## Changes
The `fs.readFileSync` is now wrapped in a try-catch to prevent failures. Since it's just a cache, it will proceed as a no-hit.