### PR TITLE
feat: transform dynamic imports to read __esModule

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
 		"lint": "eslint --cache ."
 	},
 	"dependencies": {
-		"es-module-lexer": "^0.10.5",
 		"esbuild": "0.14.38"
 	},
 	"devDependencies": {
 		"@pvtnbr/eslint-config": "^0.22.0",
 		"@types/node": "^17.0.31",
 		"@types/source-map-support": "^0.5.4",
+		"es-module-lexer": "^0.10.5",
 		"eslint": "^8.15.0",
 		"magic-string": "^0.26.2",
 		"pkgroll": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"lint": "eslint --cache ."
 	},
 	"dependencies": {
+		"es-module-lexer": "^0.10.5",
 		"esbuild": "0.14.38"
 	},
 	"devDependencies": {
@@ -33,6 +34,7 @@
 		"@types/node": "^17.0.31",
 		"@types/source-map-support": "^0.5.4",
 		"eslint": "^8.15.0",
+		"magic-string": "^0.26.2",
 		"pkgroll": "^1.2.2",
 		"source-map-support": "^0.5.21",
 		"typescript": "^4.6.4"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"esbuild": "0.14.38"
 	},
 	"devDependencies": {
+		"@ampproject/remapping": "^2.2.0",
 		"@pvtnbr/eslint-config": "^0.22.0",
 		"@types/node": "^17.0.31",
 		"@types/source-map-support": "^0.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@ampproject/remapping': ^2.2.0
   '@pvtnbr/eslint-config': ^0.22.0
   '@types/node': ^17.0.31
   '@types/source-map-support': ^0.5.4
@@ -16,6 +17,7 @@ dependencies:
   esbuild: 0.14.38
 
 devDependencies:
+  '@ampproject/remapping': 2.2.0
   '@pvtnbr/eslint-config': 0.22.0_hcfsmds2fshutdssjqluwm76uu
   '@types/node': 17.0.31
   '@types/source-map-support': 0.5.4
@@ -27,6 +29,14 @@ devDependencies:
   typescript: 4.6.4
 
 packages:
+
+  /@ampproject/remapping/2.2.0:
+    resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.1.1
+      '@jridgewell/trace-mapping': 0.3.13
+    dev: true
 
   /@babel/code-frame/7.16.7:
     resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
@@ -79,6 +89,35 @@ packages:
 
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@jridgewell/gen-mapping/0.1.1:
+    resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.1
+      '@jridgewell/sourcemap-codec': 1.4.13
+    dev: true
+
+  /@jridgewell/resolve-uri/3.0.7:
+    resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array/1.1.1:
+    resolution: {integrity: sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.13:
+    resolution: {integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.13:
+    resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.7
+      '@jridgewell/sourcemap-codec': 1.4.13
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,16 @@ specifiers:
   '@pvtnbr/eslint-config': ^0.22.0
   '@types/node': ^17.0.31
   '@types/source-map-support': ^0.5.4
+  es-module-lexer: ^0.10.5
   esbuild: 0.14.38
   eslint: ^8.15.0
+  magic-string: ^0.26.2
   pkgroll: ^1.2.2
   source-map-support: ^0.5.21
   typescript: ^4.6.4
 
 dependencies:
+  es-module-lexer: 0.10.5
   esbuild: 0.14.38
 
 devDependencies:
@@ -18,6 +21,7 @@ devDependencies:
   '@types/node': 17.0.31
   '@types/source-map-support': 0.5.4
   eslint: 8.15.0
+  magic-string: 0.26.2
   pkgroll: 1.2.2_typescript@4.6.4
   source-map-support: 0.5.21
   typescript: 4.6.4
@@ -713,6 +717,10 @@ packages:
       string.prototype.trimstart: 1.0.5
       unbox-primitive: 1.0.2
     dev: true
+
+  /es-module-lexer/0.10.5:
+    resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
+    dev: false
 
   /es-shim-unscopables/1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
@@ -1862,8 +1870,8 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string/0.26.1:
-    resolution: {integrity: sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==}
+  /magic-string/0.26.2:
+    resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
@@ -2151,7 +2159,7 @@ packages:
       '@rollup/plugin-replace': 4.0.0_rollup@2.72.1
       '@rollup/pluginutils': 4.2.1
       esbuild: 0.14.38
-      magic-string: 0.26.1
+      magic-string: 0.26.2
       rollup: 2.72.1
       typescript: 4.6.4
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
-  es-module-lexer: 0.10.5
   esbuild: 0.14.38
 
 devDependencies:
   '@pvtnbr/eslint-config': 0.22.0_hcfsmds2fshutdssjqluwm76uu
   '@types/node': 17.0.31
   '@types/source-map-support': 0.5.4
+  es-module-lexer: 0.10.5
   eslint: 8.15.0
   magic-string: 0.26.2
   pkgroll: 1.2.2_typescript@4.6.4
@@ -720,7 +720,7 @@ packages:
 
   /es-module-lexer/0.10.5:
     resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
-    dev: false
+    dev: true
 
   /es-shim-unscopables/1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}

--- a/src/@types/es-module-lexer.d.ts
+++ b/src/@types/es-module-lexer.d.ts
@@ -1,0 +1,3 @@
+declare module 'es-module-lexer/js' {
+	export { parse } from 'es-module-lexer';
+}

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -54,29 +54,6 @@ export function transformSync(
 	filePath: string,
 	extendOptions?: TransformOptions,
 ): TransformResult {
-	if (isCJS(filePath)) {
-		const hash = sha1(code);
-		const cacheHit = cache.get(hash);
-		if (cacheHit) {
-			return cacheHit;
-		}
-
-		const dynamicImportTranformed = transformDynamicImport(code);
-		if (dynamicImportTranformed) {
-			code = dynamicImportTranformed.code;
-		}
-
-		const result = {
-			code,
-			map: '',
-			warnings: [],
-		};
-
-		cache.set(hash, result);
-
-		return result;
-	}
-
 	const options = getTransformOptions({
 		sourcefile: filePath,
 		...extendOptions,

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -61,9 +61,10 @@ export function transformSync(
 
 	const transformed = esbuildTransformSync(code, options);
 
-	const dynamicImportTranformed = transformDynamicImport(transformed.code);
-	if (dynamicImportTranformed) {
-		transformed.code = dynamicImportTranformed.code;
+	const dynamicImportTransformed = transformDynamicImport(transformed, sourcemap);
+	if (dynamicImportTransformed) {
+		transformed.code = dynamicImportTransformed.code;
+		transformed.map = dynamicImportTransformed.map;
 	}
 
 	if (transformed.warnings.length > 0) {
@@ -97,9 +98,10 @@ export async function transform(
 
 	const transformed = await esbuildTransform(code, options);
 
-	const dynamicImportTranformed = transformDynamicImport(transformed.code);
-	if (dynamicImportTranformed) {
-		transformed.code = dynamicImportTranformed.code;
+	const dynamicImportTransformed = transformDynamicImport(transformed, sourcemap);
+	if (dynamicImportTransformed) {
+		transformed.code = dynamicImportTransformed.code;
+		transformed.map = dynamicImportTransformed.map;
 	}
 
 	if (transformed.warnings.length > 0) {

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -9,12 +9,6 @@ import { sha1 } from '../utils/sha1';
 import { hasNativeSourceMapSupport } from '../utils/has-native-source-map-support';
 import cache from './cache';
 
-// Check if file is explicitly a CJS file
-const isCJS = (sourcePath: string) => (
-	sourcePath.endsWith('.cjs')
-	|| sourcePath.endsWith('.cjs.js')
-);
-
 const nodeVersion = process.versions.node;
 
 const sourcemap = hasNativeSourceMapSupport ? 'inline' : true;
@@ -90,29 +84,6 @@ export async function transform(
 	filePath: string,
 	extendOptions?: TransformOptions,
 ): Promise<TransformResult> {
-	if (isCJS(filePath)) {
-		const hash = sha1(code);
-		const cacheHit = cache.get(hash);
-		if (cacheHit) {
-			return cacheHit;
-		}
-
-		const dynamicImportTranformed = transformDynamicImport(code);
-		if (dynamicImportTranformed) {
-			code = dynamicImportTranformed.code;
-		}
-
-		const result = {
-			code,
-			map: '',
-			warnings: [],
-		};
-
-		cache.set(hash, result);
-
-		return result;
-	}
-
 	const options = getTransformOptions({
 		sourcefile: filePath,
 		...extendOptions,

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -55,11 +55,26 @@ export function transformSync(
 	extendOptions?: TransformOptions,
 ): TransformResult {
 	if (isCJS(filePath)) {
-		return {
+		const hash = sha1(code);
+		const cacheHit = cache.get(hash);
+		if (cacheHit) {
+			return cacheHit;
+		}
+
+		const dynamicImportTranformed = transformDynamicImport(code);
+		if (dynamicImportTranformed) {
+			code = dynamicImportTranformed.code;
+		}
+
+		const result = {
 			code,
 			map: '',
 			warnings: [],
 		};
+
+		cache.set(hash, result);
+
+		return result;
 	}
 
 	const options = getTransformOptions({
@@ -99,11 +114,26 @@ export async function transform(
 	extendOptions?: TransformOptions,
 ): Promise<TransformResult> {
 	if (isCJS(filePath)) {
-		return {
+		const hash = sha1(code);
+		const cacheHit = cache.get(hash);
+		if (cacheHit) {
+			return cacheHit;
+		}
+
+		const dynamicImportTranformed = transformDynamicImport(code);
+		if (dynamicImportTranformed) {
+			code = dynamicImportTranformed.code;
+		}
+
+		const result = {
 			code,
 			map: '',
 			warnings: [],
 		};
+
+		cache.set(hash, result);
+
+		return result;
 	}
 
 	const options = getTransformOptions({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './source-map-support';
 export * from './esbuild';
+export * from './transform-dynamic-import';

--- a/src/transform-dynamic-import.ts
+++ b/src/transform-dynamic-import.ts
@@ -22,8 +22,14 @@ export function transformDynamicImport(
 		return;
 	}
 
-	const [imports] = parse(code);
+	const parsed = parse(code);
 
+	// Uninitialized
+	if ('then' in parsed) {
+		return;
+	}
+
+	const [imports] = parsed;
 	if (imports.length === 0) {
 		return;
 	}

--- a/src/transform-dynamic-import.ts
+++ b/src/transform-dynamic-import.ts
@@ -1,0 +1,43 @@
+import { parse } from 'es-module-lexer';
+import MagicString from 'magic-string';
+
+const checkEsModule = `.then((mod)=>{
+	const exports = Object.keys(mod);
+	if(
+		exports.length===1&&exports[0]==='default'&&mod.default.__esModule
+	){
+		return mod.default
+	}
+
+	return mod
+})`.replace(/[\n\t]+/g, '');
+
+export function transformDynamicImport(
+	code: string | Buffer,
+) {
+	code = code.toString();
+
+	// Naive check
+	if (!code.includes('import')) {
+		return;
+	}
+
+	const [imports] = parse(code);
+
+	if (imports.length === 0) {
+		return;
+	}
+
+	const transform = new MagicString(code);
+
+	// Only dynamic imports should be left post-transform
+	for (const dynamicImport of imports) {
+		if (dynamicImport.d > -1) {
+			transform.appendRight(dynamicImport.se, checkEsModule);
+		}
+	}
+
+	return {
+		code: transform.toString(),
+	};
+}

--- a/src/transform-dynamic-import.ts
+++ b/src/transform-dynamic-import.ts
@@ -51,7 +51,6 @@ export function transformDynamicImport(
 
 	const magicString = new MagicString(code);
 
-	// Only dynamic imports should be left post-transform
 	for (const dynamicImport of imports) {
 		if (dynamicImport.d > -1) {
 			magicString.appendRight(dynamicImport.se, checkEsModule);


### PR DESCRIPTION
## Problem
Dynamic imports didn't check for `__esModule` property so it can't correctly interop with ESM/TS-to-CJS compiled modules

## Changes
-  Dynamic imports get transformed to check `__esModule` property in case the imported module has been transformed (related: https://github.com/evanw/esbuild/issues/2253)
- `isCJS` check removed:
  - `transformSync`: transforming CJS is necessary for Node.js v12.16.2 where `import()` is not supported, and needs to be transformed to `require()`
  - `transform`: Used by esm-loader, and doesn't handle `.cjs` files (delegates to cjs-loader because it requires CJS context eg. `__dirname`)


