### PR TITLE
fix: handle extension-less files

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -37,20 +37,17 @@ const getTransformOptions = (
 
 	if (options.sourcefile) {
 		let { sourcefile } = options;
-
 		const extension = path.extname(sourcefile);
 
 		if (extension) {
 			// https://github.com/evanw/esbuild/issues/1932
 			if (extension === '.cts' || extension === '.mts') {
-				sourcefile = `${sourcefile.slice(0, -3)}ts`;
+				options.sourcefile = `${sourcefile.slice(0, -3)}ts`;
 			}
 		} else {
 			// esbuild errors to detect loader when a file doesn't have an extension
-			sourcefile += '.js';
+			options.sourcefile += '.js';
 		}
-
-		options.sourcefile = sourcefile;
 	}
 
 	return options;

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { TransformOptions, TransformResult } from 'esbuild';
 import {
 	transform as esbuildTransform,
@@ -35,8 +36,21 @@ const getTransformOptions = (
 	};
 
 	if (options.sourcefile) {
-		// https://github.com/evanw/esbuild/issues/1932
-		options.sourcefile = options.sourcefile.replace(/\.[cm]ts/, '.ts');
+		let { sourcefile } = options;
+
+		const extension = path.extname(sourcefile);
+
+		if (extension) {
+			// https://github.com/evanw/esbuild/issues/1932
+			if (extension === '.cts' || extension === '.mts') {
+				sourcefile = `${sourcefile.slice(0, -3)}ts`;
+			}
+		} else {
+			// esbuild errors to detect loader when a file doesn't have an extension
+			sourcefile += '.js';
+		}
+
+		options.sourcefile = sourcefile;
 	}
 
 	return options;

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -36,7 +36,7 @@ const getTransformOptions = (
 	};
 
 	if (options.sourcefile) {
-		let { sourcefile } = options;
+		const { sourcefile } = options;
 		const extension = path.extname(sourcefile);
 
 		if (extension) {


### PR DESCRIPTION
When importing an extension-less file (eg. [tsc](https://unpkg.com/typescript@4.6.4/bin/tsc)), esbuild throws an error because it can't detect which loader to use.