### PR TITLE
fix: native source maps will not work if prepareStackTrace overwritten

### DIFF
--- a/src/utils/has-native-source-map-support.ts
+++ b/src/utils/has-native-source-map-support.ts
@@ -1,1 +1,7 @@
-export const hasNativeSourceMapSupport = 'setSourceMapsEnabled' in process;
+// Check if native source maps are supported by seeing if the programatic api is available.
+// https://nodejs.org/dist/latest-v18.x/docs/api/process.html#processsetsourcemapsenabledval
+
+// Also check if `Error.prepareStackTrace` has been set as that makes native source maps not work.
+// https://nodejs.org/dist/latest-v18.x/docs/api/cli.html#:~:text=Overriding%20Error.prepareStackTrace%20prevents%20%2D%2Denable%2Dsource%2Dmaps%20from%20modifying%20the%20stack%20trace.
+
+export const hasNativeSourceMapSupport = !Error.prepareStackTrace && 'setSourceMapsEnabled' in process;


### PR DESCRIPTION
Currently if `Error.prepareStackTrace` is set node js will ignore native source maps.
This PR checks to see if it is set before determining if we can enable native source maps.

That property may be set by many other tools, especially if eg combining loaders, this now falls back accordingly. 