### PR TITLE
fix: check if `Error.prepareStackTrace` is function

### DIFF
--- a/src/utils/has-native-source-map-support.ts
+++ b/src/utils/has-native-source-map-support.ts
@@ -8,7 +8,7 @@ export const hasNativeSourceMapSupport = (
 	/**
 	 * Overriding Error.prepareStackTrace prevents --enable-source-maps from modifying the stack trace
 	 * https://nodejs.org/dist/latest-v18.x/docs/api/cli.html#:~:text=Overriding%20Error.prepareStackTrace%20prevents%20%2D%2Denable%2Dsource%2Dmaps%20from%20modifying%20the%20stack%20trace.
-	 * 
+	 *
 	 * https://github.com/nodejs/node/blob/91193825551f9301b6ab52d96211b38889149892/lib/internal/errors.js#L141
 	 */
 	&& typeof Error.prepareStackTrace !== 'function'


### PR DESCRIPTION
Minor refactor to https://github.com/esbuild-kit/core-utils/pull/13 to use the same check as Node.js