### PR TITLE
fix: prevent mkdir race condition on cache directory

### DIFF
--- a/src/transform/cache.ts
+++ b/src/transform/cache.ts
@@ -28,9 +28,7 @@ class FileCache extends Map<string, TransformResult> {
 	constructor() {
 		super();
 
-		if (!fs.existsSync(this.cacheDirectory)) {
-			fs.mkdirSync(this.cacheDirectory);
-		}
+		fs.mkdirSync(this.cacheDirectory, { recursive: true });
 
 		this.cacheFiles = fs.readdirSync(this.cacheDirectory).map((fileName) => {
 			const [time, key] = fileName.split('-');

--- a/src/transform/cache.ts
+++ b/src/transform/cache.ts
@@ -28,6 +28,7 @@ class FileCache extends Map<string, TransformResult> {
 	constructor() {
 		super();
 
+		// Handles race condition if multiple tsx instances are running (#22)
 		fs.mkdirSync(this.cacheDirectory, { recursive: true });
 
 		this.cacheFiles = fs.readdirSync(this.cacheDirectory).map((fileName) => {


### PR DESCRIPTION
When running multiple copies of `tsx` in parallel (i.e. with concurrently/npm-run-all), a race condition can occur where the cache directory is created by another process after the exists check has returned false. This results in the following error, because the mkdirSync is trying to create something that already exists:

```
Error: EEXIST: file already exists, mkdir '/tmp/esbuild-kit'
    at Object.mkdirSync (node:fs:1334:3)
```

This fix resolves that by using mkdirSync's recursive mode, where it both creates missing parent directories and also does not error if the directory already exists.

Note: not sure which versions of Node are targeted, but fwiw this param exists at least back to Node 12 (https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_mkdirsync_path_options)