### PR TITLE
fix: keep names in esbuild minification

### DIFF
--- a/src/transform/get-esbuild-options.ts
+++ b/src/transform/get-esbuild-options.ts
@@ -23,7 +23,8 @@ export const getEsbuildOptions = (
 		 * Disabled until esbuild supports names in source maps:
 		 * https://github.com/evanw/esbuild/issues/1296
 		 */
-		// minify: true, keepNames: true,
+		// minify: true,
+		keepNames: true,
 		minifySyntax: true,
 		minifyWhitespace: true,
 

--- a/tests/specs/transform.ts
+++ b/tests/specs/transform.ts
@@ -9,11 +9,13 @@ const fixtures = {
 	ts: `
 	export default 'default value' as string;
 	export const named: string = 'named';
+	export const functionName: string = (function named() {}).name;
 	`,
 
 	esm: `
 	export default 'default value';
 	export const named = 'named';
+	export const functionName = (function named() {}).name;
 	`,
 };
 
@@ -33,9 +35,11 @@ export default testSuite(({ describe }) => {
 					'/file.js': transformed.code,
 				}));
 
-				expect(JSON.stringify(fsRequire('/file.js'))).toBe(
-					'{"default":"default value","named":"named"}',
-				);
+				expect(fsRequire('/file.js')).toStrictEqual({
+					default: 'default value',
+					functionName: 'named',
+					named: 'named',
+				});
 			});
 
 			test('transforms file with inline sourcemap string', () => {
@@ -83,7 +87,11 @@ export default testSuite(({ describe }) => {
 				);
 
 				const imported = await import(base64Module(transformed.code));
-				expect(JSON.stringify(imported)).toMatch('{"default":"default value","named":"named"}');
+				expect({ ...imported }).toStrictEqual({
+					default: 'default value',
+					functionName: 'named',
+					named: 'named',
+				});
 			});
 
 			test('sourcemap file', async () => {


### PR DESCRIPTION
## Problem
`keepNames` was disabled in https://github.com/esbuild-kit/core-utils/pull/10 because of the assumption that only [`minify-identifiers`](https://esbuild.github.io/api/#minify) would remove names, but turns out [`minify-syntax` does too](https://hyrious.me/esbuild-repl/?version=0.15.5&mode=transform&input=%28function+helloworld%28%29%7B%7D%29.name&options=--minify-syntax).

## Changes
Re-enable `keepNames`.

## Other info
From https://github.com/esbuild-kit/cjs-loader/issues/19
