### PR TITLE
feat: re-enable identifier minification

### DIFF
--- a/src/transform/get-esbuild-options.ts
+++ b/src/transform/get-esbuild-options.ts
@@ -19,14 +19,8 @@ export const getEsbuildOptions = (
 		 * Smaller output for cache and marginal performance improvement:
 		 * https://twitter.com/evanwallace/status/1396336348366180359?s=20
 		 */
-		/**
-		 * Disabled until esbuild supports names in source maps:
-		 * https://github.com/evanw/esbuild/issues/1296
-		 */
-		// minify: true,
+		minify: true,
 		keepNames: true,
-		minifySyntax: true,
-		minifyWhitespace: true,
 
 		...extendOptions,
 	};

--- a/tests/specs/transform.ts
+++ b/tests/specs/transform.ts
@@ -73,6 +73,7 @@ export default testSuite(({ describe }) => {
 
 				expect(map.sources.length).toBe(1);
 				expect(map.sources[0]).toBe(fileName);
+				expect(map.names).toStrictEqual(['file_default', 'named', 'functionName', '__name']);
 			});
 		});
 
@@ -110,6 +111,7 @@ export default testSuite(({ describe }) => {
 
 				expect(map.sources.length).toBe(1);
 				expect(map.sources[0]).toBe(fileName);
+				expect(map.names).toStrictEqual(['file_default', 'named', 'functionName', '__name']);
 			});
 		});
 	});


### PR DESCRIPTION
## Problem
Identifier minificaiton was disabled in https://github.com/esbuild-kit/core-utils/issues/7 because esbuild previously didn't support `names` in source maps. Now it does.

## Changes
Re-enable full minification
