### PR TITLE
Feature: override loader

### DIFF
--- a/src/transform/get-esbuild-options.ts
+++ b/src/transform/get-esbuild-options.ts
@@ -1,17 +1,19 @@
 import path from 'path';
 import type { TransformOptions } from 'esbuild';
+import { getLoader } from './get-loader';
 
 const nodeVersion = process.versions.node;
 
 export const getEsbuildOptions = (
 	extendOptions: TransformOptions,
 ) => {
+	const { sourcefile } = extendOptions;
+	const extension = sourcefile && path.extname(sourcefile);
+
 	const options: TransformOptions = {
 		target: `node${nodeVersion}`,
 
-		// "default" tells esbuild to infer loader from file name
-		// https://github.com/evanw/esbuild/blob/4a07b17adad23e40cbca7d2f8931e8fb81b47c33/internal/bundler/bundler.go#L158
-		loader: 'default',
+		loader: getLoader(extension),
 
 		sourcemap: true,
 
@@ -31,10 +33,7 @@ export const getEsbuildOptions = (
 		...extendOptions,
 	};
 
-	if (options.sourcefile) {
-		const { sourcefile } = options;
-		const extension = path.extname(sourcefile);
-
+	if (sourcefile) {
 		if (extension) {
 			// https://github.com/evanw/esbuild/issues/1932
 			if (extension === '.cts' || extension === '.mts') {

--- a/src/transform/get-loader.ts
+++ b/src/transform/get-loader.ts
@@ -1,21 +1,28 @@
 import type { Loader } from 'esbuild';
 
-const loaderMap = (() => {
-	const map = new Map<string, Loader>();
+const loaderMap = new Map<string, Loader>();
+let parsedEnv: string | undefined;
 
-	if (process.env.ESBK_LOADER_MAP) {
-		const entries = process.env.ESBK_LOADER_MAP.split(',');
+const parseEnv = () => {
+	if (parsedEnv === process.env.ESBK_LOADER_MAP) {
+		return;
+	}
+
+	loaderMap.clear();
+	parsedEnv = process.env.ESBK_LOADER_MAP;
+
+	if (parsedEnv) {
+		const entries = parsedEnv.split(',');
 
 		for (const entry of entries) {
 			const [extension, loader] = entry.trim().split('=');
-			map.set(extension, loader as Loader);
+			loaderMap.set(extension, loader as Loader);
 		}
 	}
-
-	return map;
-})();
+};
 
 export const getLoader = (extension?: string): Loader => {
+	parseEnv();
 	const override = extension ? loaderMap.get(extension) : undefined;
 
 	// "default" tells esbuild to infer loader from file name

--- a/src/transform/get-loader.ts
+++ b/src/transform/get-loader.ts
@@ -1,0 +1,24 @@
+import type { Loader } from 'esbuild';
+
+const loaderMap = (() => {
+	const map = new Map<string, Loader>();
+
+	if (process.env.ESBK_LOADER_MAP) {
+		const entries = process.env.ESBK_LOADER_MAP.split(',');
+
+		for (const entry of entries) {
+			const [extension, loader] = entry.trim().split('=');
+			map.set(extension, loader as Loader);
+		}
+	}
+
+	return map;
+})();
+
+export const getLoader = (extension?: string): Loader => {
+	const override = extension ? loaderMap.get(extension) : undefined;
+
+	// "default" tells esbuild to infer loader from file name
+	// https://github.com/evanw/esbuild/blob/4a07b17adad23e40cbca7d2f8931e8fb81b47c33/internal/bundler/bundler.go#L158
+	return override ?? 'default';
+};

--- a/tests/specs/transform.ts
+++ b/tests/specs/transform.ts
@@ -125,5 +125,35 @@ export default testSuite(({ describe }) => {
 				expect(map.names).toStrictEqual(['named']);
 			});
 		});
+
+		describe('loader mappings', async ({ test }) => {
+			await test('configure loader for html', async () => {
+				const oldEnv = process.env.ESBK_LOADER_MAP;
+
+				try {
+					process.env.ESBK_LOADER_MAP = '.html=text';
+
+					const transformed = await transform(
+						'<html></html>',
+						'file.html',
+						{ format: 'esm' },
+					);
+
+					expect(transformed.code).toBe('var file_default="<html></html>";export{file_default as default};\n');
+				} finally {
+					process.env.ESBK_LOADER_MAP = oldEnv;
+				}
+			});
+
+			await test('error without loader for html', async () => {
+				const promise = transform(
+					'<html></html>',
+					'file.html',
+					{ format: 'esm' },
+				);
+
+				await expect(promise).rejects.toThrow('error: Do not know how to load path: file.html');
+			});
+		});
 	});
 });


### PR DESCRIPTION
It would be nice to have the option to define loaders for arbitrary file extensions. esbuild automatically chooses a loader based on the filename, but that is limited to a small list of known file extensions, e.g., the loader `text` is used for `.txt` files. (See https://esbuild.github.io/content-types/#text)

esbuild itself and other tools based on it, like tsup, allow overriding loaders with CLI parameters like `--loader:.html=text` or `--loader ".html=text"`.

My suggestion is to allow esm-loader and cjs-loader to be configured via environment variables like this:

```bash
ESBK_LOADER_MAP=.html=text,.png=base64 tsx watch index.ts
```

When the loaders support it, tsx could get respective command line parameters, which set the env var internally. Similar to `--tsconfig`.

**Optional** The mapping could be more sophisticated by matching globs via minimatch.
