### PR TITLE
fix: `@types/source-map-support` as an optional peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
 		"esbuild": "~0.17.8",
 		"source-map-support": "^0.5.21"
 	},
+	"peerDependencies": {
+		"@types/source-map-support": "^0.5.6"
+	},
+	"peerDependenciesMeta": {
+		"@types/source-map-support": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@ampproject/remapping": "^2.2.0",
 		"@pvtnbr/eslint-config": "^0.33.0",


### PR DESCRIPTION
TODO: Update pkgroll to silence warning when type-dependency is in another external dependency object (e.g. peerDependencies)